### PR TITLE
Fix vertical sprite loading

### DIFF
--- a/sprite_game.py
+++ b/sprite_game.py
@@ -40,12 +40,12 @@ class Player:
             self.sprite_frames['left'] = self.sprite_frames['right']  # Usamos flip para izquierda
         
         # Cargar sprite para movimiento hacia arriba
-        if 'back' in sprite_sheets:
-            self.sprite_frames['up'] = self.load_sprite_frames(sprite_sheets['back'])
+        if 'up' in sprite_sheets:
+            self.sprite_frames['up'] = self.load_sprite_frames(sprite_sheets['up'])
         
         # Cargar sprite para movimiento hacia abajo
-        if 'front' in sprite_sheets:
-            self.sprite_frames['down'] = self.load_sprite_frames(sprite_sheets['front'])
+        if 'down' in sprite_sheets:
+            self.sprite_frames['down'] = self.load_sprite_frames(sprite_sheets['down'])
         
         # Sprite por defecto
         self.current_direction = 'down'


### PR DESCRIPTION
## Summary
- fix sprite keys used by `Player` constructor

## Testing
- `python -m py_compile sprite_game.py`
- *(fails: ModuleNotFoundError: No module named 'pygame' when running the game)*

------
https://chatgpt.com/codex/tasks/task_e_687c6a0523f483319bba87979f1622bd